### PR TITLE
Fix LuckPerms integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,15 @@
     </repository>
   </distributionManagement>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <!-- This is a temporary reference as the Maven Shade plugin
+          that supports Java 16 is not released yet -->
+      <id>maven-snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
     <finalName>${project.artifactId}</finalName>
     <defaultGoal>clean javadoc:jar source:jar deploy</defaultGoal>
@@ -69,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.3.0-SNAPSHOT</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>

--- a/src/main/java/org/bitbucket/ucchy/undine/bridge/LuckPermsBridge.java
+++ b/src/main/java/org/bitbucket/ucchy/undine/bridge/LuckPermsBridge.java
@@ -1,17 +1,18 @@
 package org.bitbucket.ucchy.undine.bridge;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.UUID;
-
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.model.user.UserManager;
 import net.luckperms.api.node.matcher.NodeMatcher;
 import net.luckperms.api.node.types.InheritanceNode;
-
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
 
 /**
  * LuckPermsへアクセスするためのブリッジクラス
@@ -23,10 +24,11 @@ public class LuckPermsBridge {
     /**
      * コンストラクタは使用不可
      */
-    private LuckPermsBridge() {
+    private LuckPermsBridge(LuckPerms luckPerms) {
+        this.luckperms = luckPerms;
     }
 
-    public static LuckPerms luckperms = null;
+    private final LuckPerms luckperms;
 
     /**
      * LuckPermsをロードする
@@ -36,10 +38,9 @@ public class LuckPermsBridge {
      */
     public static LuckPermsBridge load(Plugin plugin) {
         if (plugin == null) return null;
-        if (!(plugin instanceof LuckPerms)) {
-            return null;
-        }
-        return new LuckPermsBridge();
+        RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
+        if (provider == null) return null;
+        return new LuckPermsBridge(provider.getProvider());
     }
 
     /**


### PR DESCRIPTION
FYI: https://luckperms.net/wiki/Developer-API#using-the-bukkit-servicesmanager
Spigot 1.17.1 + LuckPermsにてグループへのメール送信の動作確認済み
![image](https://user-images.githubusercontent.com/41550858/137308320-4fc0953c-423c-4461-b680-f9a0513aa2b5.png)
